### PR TITLE
Fix component config parameter in package class

### DIFF
--- a/package/main.yml
+++ b/package/main.yml
@@ -27,7 +27,7 @@ parameters:
       version: v1.3.0
     openshift4-service-mesh:
       url: https://github.com/appuio/component-openshift4-service-mesh
-      version: v1.0.0
+      version: v1.0.1
       path: component
 
   syn_openshift_distributed_tracing:
@@ -48,6 +48,6 @@ parameters:
         source: redhat-operators
         installPlanApproval: ${pkg.openshift4_service_mesh:kiali:installPlanApproval}
 
-  openshift_service_mesh:
+  openshift4_service_mesh:
     operator: ${pkg.openshift4_service_mesh:operator}
     es_operator: ${pkg.openshift4_service_mesh:es_operator}

--- a/package/tests/defaults.yml
+++ b/package/tests/defaults.yml
@@ -1,3 +1,8 @@
 ---
 classes:
   - ..preview
+
+parameters:
+  pkg.openshift4_service_mesh:
+    operator:
+      installPlanApproval: Manual

--- a/package/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/operator.yaml
+++ b/package/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/operator.yaml
@@ -16,7 +16,7 @@ metadata:
   namespace: syn-openshift-service-mesh
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: servicemeshoperator
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
We mistakenly used `openshift_service_mesh` to pass through the package config to component openshift4-service-mesh.

This commit adjusts the package class to correctly use parameter `openshift4_service_mesh`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
