### PR TITLE
Always install the RedHat elasticsearch-operator in openshift-operators-redhat

### DIFF
--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -17,8 +17,6 @@ local needs_es_operator =
   });
   !logging_params.components.elasticsearch.enabled;
 
-local es_operator_ns = '%s-es-operator' % params.namespace;
-
 local operatorlib = import 'lib/openshift4-operators.libsonnet';
 
 // Define outputs below
@@ -41,24 +39,8 @@ local operatorlib = import 'lib/openshift4-operators.libsonnet';
     },
   },
   [if needs_es_operator then 'es_operator']: [
-    kube.Namespace(es_operator_ns) {
-      metadata+: {
-        annotations+: {
-          'openshift.io/node-selector': 'node-role.kubernetes.io/infra=',
-        },
-        labels+: {
-          // include namespace in cluster monitoring
-          'openshift.io/cluster-monitoring': 'true',
-        },
-      },
-    },
-    operatorlib.OperatorGroup(es_operator_ns) {
-      metadata+: {
-        namespace: es_operator_ns,
-      },
-    },
     operatorlib.namespacedSubscription(
-      es_operator_ns,
+      'openshift-operators-redhat',
       'elasticsearch-operator',
       params.es_operator.channel,
       source='redhat-operators',

--- a/component/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/es_operator.yaml
+++ b/component/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/es_operator.yaml
@@ -1,22 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/node-selector: node-role.kubernetes.io/infra=
-  labels:
-    name: syn-openshift-service-mesh-es-operator
-    openshift.io/cluster-monitoring: 'true'
-  name: syn-openshift-service-mesh-es-operator
----
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  annotations: {}
-  labels:
-    name: syn-openshift-service-mesh-es-operator
-  name: syn-openshift-service-mesh-es-operator
-  namespace: syn-openshift-service-mesh-es-operator
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -24,7 +5,7 @@ metadata:
   labels:
     name: elasticsearch-operator
   name: elasticsearch-operator
-  namespace: syn-openshift-service-mesh-es-operator
+  namespace: openshift-operators-redhat
 spec:
   channel: stable
   installPlanApproval: Automatic


### PR DESCRIPTION
The operator doesn't cleanly support installation in a different namespace, since it hardcodes the metrics service name in the servicemonitor which it creates to contain namespace name `openshift-operators-redhat`.

Fixes #5




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
