### PR TITLE
Generate optional operator subscription for Jaeger in component-openshift4-service-mesh

### DIFF
--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -12,3 +12,9 @@ parameters:
       enabled: true
       channel: stable
       installPlanApproval: Automatic
+
+    distributed_tracing_operator:
+      enabled: true
+      namespace: syn-openshift-distributed-tracing
+      channel: stable
+      installPlanApproval: Automatic

--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -59,8 +59,8 @@ local operatorlib = import 'lib/openshift4-operators.libsonnet';
           'openshift.io/node-selector': '',
         },
         labels+: {
-          // ignore namespace in cluster monitoring
-          'openshift.io/cluster-monitoring': 'false',
+          // include namespace in cluster monitoring
+          'openshift.io/cluster-monitoring': 'true',
           // ignore namespace in user-workload monitoring
           'openshift.io/user-monitoring': 'false',
         },

--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -20,6 +20,8 @@ local needs_es_operator =
   params.es_operator.enabled &&
   !std.get(logging_params.components, 'elasticsearch', { enabled: false }).enabled;
 
+local needs_dt_operator = params.distributed_tracing_operator.enabled;
+
 local operatorlib = import 'lib/openshift4-operators.libsonnet';
 
 // Define outputs below
@@ -48,6 +50,33 @@ local operatorlib = import 'lib/openshift4-operators.libsonnet';
       params.es_operator.channel,
       source='redhat-operators',
       installPlanApproval=params.es_operator.installPlanApproval,
+    ),
+  ],
+  [if needs_dt_operator then 'distributed_tracing_operator']: [
+    kube.Namespace(params.distributed_tracing_operator.namespace) {
+      metadata+: {
+        annotations+: {
+          'openshift.io/node-selector': '',
+        },
+        labels+: {
+          // ignore namespace in cluster monitoring
+          'openshift.io/cluster-monitoring': 'false',
+          // ignore namespace in user-workload monitoring
+          'openshift.io/user-monitoring': 'false',
+        },
+      },
+    },
+    operatorlib.OperatorGroup(params.distributed_tracing_operator.namespace) {
+      metadata+: {
+        namespace: params.distributed_tracing_operator.namespace,
+      },
+    },
+    operatorlib.namespacedSubscription(
+      params.distributed_tracing_operator.namespace,
+      'jaeger-product',
+      params.distributed_tracing_operator.channel,
+      source='redhat-operators',
+      installPlanApproval=params.distributed_tracing_operator.installPlanApproval,
     ),
   ],
   operator: [

--- a/component/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/distributed_tracing_operator.yaml
+++ b/component/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/distributed_tracing_operator.yaml
@@ -5,7 +5,7 @@ metadata:
     openshift.io/node-selector: ''
   labels:
     name: syn-openshift-distributed-tracing
-    openshift.io/cluster-monitoring: 'false'
+    openshift.io/cluster-monitoring: 'true'
     openshift.io/user-monitoring: 'false'
   name: syn-openshift-distributed-tracing
 ---

--- a/component/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/distributed_tracing_operator.yaml
+++ b/component/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/distributed_tracing_operator.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: syn-openshift-distributed-tracing
+    openshift.io/cluster-monitoring: 'false'
+    openshift.io/user-monitoring: 'false'
+  name: syn-openshift-distributed-tracing
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations: {}
+  labels:
+    name: syn-openshift-distributed-tracing
+  name: syn-openshift-distributed-tracing
+  namespace: syn-openshift-distributed-tracing
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: jaeger-product
+  name: jaeger-product
+  namespace: syn-openshift-distributed-tracing
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: jaeger-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -45,11 +45,9 @@ NOTE: This operator is installed through component `openshift4-operators`.
 
 [horizontal]
 type: object
-default:: `{"channel": "stable", "installPlanApproval": "Automatic"}`
+default:: `{"enabled": true, "channel": "stable", "installPlanApproval": "Automatic"}`
 
 This parameter allows users to customize the upgrade channel and mode for the distributed tracing framework (Jaeger).
-
-NOTE: This operator is installed through component `openshift4-operators`.
 
 == Component parameters
 
@@ -76,7 +74,7 @@ This parameter allows users to customize the upgrade channel and upgrade mode fo
 
 [horizontal]
 type: object
-default:: `{"channel": "stable", "installPlanApproval": "Automatic"}`
+default:: `{"enabled": true, "channel": "stable", "installPlanApproval": "Automatic"}`
 
 This parameter allows users to customize the upgrade channel and mode for the OpenShift ElasticSearch operator.
 
@@ -86,7 +84,15 @@ The ES operator is only installed by this component if it's not already installe
 If the ES operator is installed through `openshift4-logging`, this parameter has no effect.
 ====
 
+=== `distributed_tracing_operator`
+
+[horizontal]
+type: object
+default:: `{"enabled": true, "channel": "stable", "installPlanApproval": "Automatic"}`
+
+This parameter allows users to customize the upgrade channel and mode for the distributed tracing framework (Jaeger).
+
 [NOTE]
 ====
-This component installs the ES operator in namespace `<namespace>-es-operator`, where the value of the component parameter `namespace` is used for `<namespace>`.
+This component installs the Jaeger operator in namespace `<namespace>-jaeger-operator`, where the value of the component parameter `namespace` is used for `<namespace>`.
 ====


### PR DESCRIPTION
Component change which, paired with #20, allows disabling the Jaeger operator.
## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
