### PR TITLE
Generate distributed tracing operator using component-openshift4-service-mesh

### DIFF
--- a/package/main.yml
+++ b/package/main.yml
@@ -2,7 +2,6 @@
 applications:
   - openshift4-service-mesh
   - openshift4-operators as openshift-operators-redhat
-  - openshift4-operators as syn-openshift-distributed-tracing
   - openshift4-operators as syn-openshift-kiali
 
 parameters:
@@ -16,6 +15,7 @@ parameters:
       channel: stable
       installPlanApproval: Automatic
     distributed_tracing:
+      enabled: true
       channel: stable
       installPlanApproval: Automatic
     kiali:
@@ -31,15 +31,6 @@ parameters:
       version: v1.2.0
       path: component
 
-  syn_openshift_distributed_tracing:
-    useCustomNamespace: true
-    subscription:
-      name: jaeger-product
-      channel: ${pkg.openshift4_service_mesh:distributed_tracing:channel}
-      spec:
-        source: redhat-operators
-        installPlanApproval: ${pkg.openshift4_service_mesh:distributed_tracing:installPlanApproval}
-
   syn_openshift_kiali:
     useCustomNamespace: true
     subscription:
@@ -52,3 +43,4 @@ parameters:
   openshift4_service_mesh:
     operator: ${pkg.openshift4_service_mesh:operator}
     es_operator: ${pkg.openshift4_service_mesh:es_operator}
+    distributed_tracing_operator: ${pkg.openshift4_service_mesh:distributed_tracing}

--- a/package/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/distributed_tracing_operator.yaml
+++ b/package/tests/golden/defaults/openshift4-service-mesh/openshift4-service-mesh/distributed_tracing_operator.yaml
@@ -5,7 +5,7 @@ metadata:
     openshift.io/node-selector: ''
   labels:
     name: syn-openshift-distributed-tracing
-    openshift.io/cluster-monitoring: 'false'
+    openshift.io/cluster-monitoring: 'true'
     openshift.io/user-monitoring: 'false'
   name: syn-openshift-distributed-tracing
 ---
@@ -17,7 +17,6 @@ metadata:
     name: syn-openshift-distributed-tracing
   name: syn-openshift-distributed-tracing
   namespace: syn-openshift-distributed-tracing
-spec: {}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription


### PR DESCRIPTION
Packe change which, paired with #19, adds the ability to disable the distributed tracing operator.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
